### PR TITLE
propagate CompositionOptions to fetchAffordances and _getPartialTDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ packages/web-new/test-results
 packages/web-new/playwright-report
 **/coverage
 **/.nyc_output
+
+# nix
+.direnv
+.envrc
+flake.nix
+flake.lock

--- a/node/thing-model/src/tm-helpers.ts
+++ b/node/thing-model/src/tm-helpers.ts
@@ -291,7 +291,7 @@ export class ThingModelHelpers {
             throw new Error(isValid.errors);
         }
 
-        const modelInput = await this.fetchAffordances(model);
+        const modelInput = await this.fetchAffordances(model, options);
         const extendedModels = await this.composeModel(model, modelInput, options);
         return extendedModels;
     }
@@ -304,14 +304,14 @@ export class ThingModelHelpers {
      *
      * @experimental
      */
-    private async fetchAffordances(data: ThingModel): Promise<modelComposeInput> {
+    private async fetchAffordances(data: ThingModel, options?: CompositionOptions): Promise<modelComposeInput> {
         const modelInput: modelComposeInput = {};
         const extLinks = ThingModelHelpers.getThingModelLinks(data, "tm:extends");
         if (extLinks.length > 0) {
             modelInput.extends = [] as ThingModel[];
             for (const s of extLinks) {
                 let source = await this.fetchModel(s.href);
-                [source] = await this._getPartialTDs(source);
+                [source] = await this._getPartialTDs(source, options);
                 modelInput.extends.push(source);
             }
         }
@@ -325,7 +325,7 @@ export class ThingModelHelpers {
                     throw new Error(`Missing remote path in ${affUri}`);
                 }
                 let source = await this.fetchModel(refObj.uri);
-                [source] = await this._getPartialTDs(source);
+                [source] = await this._getPartialTDs(source, options);
                 delete (data[affType] as DataSchema)[aff]["tm:ref"];
                 const importedAffordance = this.getRefAffordance(refObj, source) ?? {};
                 refObj.name = aff; // update the name of the affordance

--- a/node/thing-model/test/thing-model/tmodels/placeholderExtension/BaseThingWithPlaceholder.tm.jsonld
+++ b/node/thing-model/test/thing-model/tmodels/placeholderExtension/BaseThingWithPlaceholder.tm.jsonld
@@ -1,0 +1,17 @@
+{
+    "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1"
+    ],
+    "@type": "tm:ThingModel",
+    "title": "base_thing",
+    "version": {
+        "model": "0.0.1"
+    },
+    "id": "urn:uuid:{{THING_UUID_V4}}",
+    "description": "The most basic thing",
+    "securityDefinitions": {
+        "nosec_sc": {
+            "scheme": "nosec"
+        }
+    }
+}

--- a/node/thing-model/test/thing-model/tmodels/placeholderExtension/ThingWithPlaceholder.tm.jsonld
+++ b/node/thing-model/test/thing-model/tmodels/placeholderExtension/ThingWithPlaceholder.tm.jsonld
@@ -1,0 +1,30 @@
+{
+    "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1"
+    ],
+    "@type": "tm:ThingModel",
+    "title": "extended_thing",
+    "version": {
+        "model": "0.0.1"
+    },
+    "description": "Extends the base thing with some properties",
+    "links": [{
+        "rel": "tm:extends",
+        "href": "file://./test/thing-model/tmodels/placeholderExtension/BaseThingWithPlaceholder.tm.jsonld",
+        "type": "application/tm+json"
+    }],
+    "properties": {
+        "some_property": {
+            "type": "string",
+            "description": "Some property",
+            "forms": [{
+                "href": "mqtt://{{MQTT_BROKER_ADDR}}",
+                "mqv:topic": "{{THING_MODEL}}/{{THING_UUID_V4}}/properties/some_property",
+                "op": "observeproperty",
+                "mqv:qos": 1,
+                "mqv:retain": false,
+                "contentType": "application/json"
+            }]
+        }
+    }
+}

--- a/node/thing-model/test/thing-model/tmodels/placeholderExtension/thingExtended.jsonld
+++ b/node/thing-model/test/thing-model/tmodels/placeholderExtension/thingExtended.jsonld
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1"
+  ],
+  "@type": "Thing",
+  "title": "extended_thing",
+  "id": "urn:uuid:bf2c24bc-9232-454d-ac17-90feb3647b71",
+  "description": "Extends the base thing with some properties",
+  "securityDefinitions": {
+    "nosec_sc": {
+      "scheme": "nosec"
+    }
+  },
+  "links": [
+    {
+      "rel": "type",
+      "href": "./extended_thing.tm.jsonld",
+      "type": "application/tm+json"
+    }
+  ],
+  "properties": {
+    "some_property": {
+      "type": "string",
+      "description": "Some property",
+      "forms": [
+        {
+          "href": "mqtt://example.org:1883",
+          "mqv:topic": "extended_thing/bf2c24bc-9232-454d-ac17-90feb3647b71/properties/some_property",
+          "op": "observeproperty",
+          "mqv:qos": 1,
+          "mqv:retain": false,
+          "contentType": "application/json"
+        }
+      ]
+    }
+  }
+}

--- a/node/thing-model/test/thingModelHelper.test.ts
+++ b/node/thing-model/test/thingModelHelper.test.ts
@@ -447,6 +447,29 @@ class ThingModelHelperTest {
         expect(validated.errors).to.be.equal(`Missing required fields in map for model ${thing.title}`);
     }
 
+    @test async "should correctly fill placeholders of all linked ThingModels"() {
+        const modelUri = "file://./test/thing-model/tmodels/placeholderExtension/ThingWithPlaceholder.tm.jsonld";
+        const placeholderThing = await this.thingModelHelpers.fetchModel(modelUri);
+
+        const tdUri= "./test/thing-model/tmodels/placeholderExtension/thingExtended.jsonld";
+        const td = await fs.readFile(tdUri, "utf-8");
+        const tdJson = JSON.parse(td);
+
+        const map = {
+            THING_MODEL: "extended_thing",
+            THING_UUID_V4: "bf2c24bc-9232-454d-ac17-90feb3647b71",
+            MQTT_BROKER_ADDR: "example.org:1883",
+        }
+
+        const options: CompositionOptions = {
+            map,
+            selfComposition: false,
+        };
+
+        const [partialTd] = await this.thingModelHelpers.getPartialTDs(placeholderThing, options);
+        expect(partialTd).to.be.deep.equal(tdJson);
+    }
+
     @test async "should fail on unavailable linked ThingModel - http"() {
         const thing = {
             "@context": ["https://www.w3.org/2022/wot/td/v1.1"],

--- a/node/thing-model/test/thingModelHelper.test.ts
+++ b/node/thing-model/test/thingModelHelper.test.ts
@@ -451,7 +451,7 @@ class ThingModelHelperTest {
         const modelUri = "file://./test/thing-model/tmodels/placeholderExtension/ThingWithPlaceholder.tm.jsonld";
         const placeholderThing = await this.thingModelHelpers.fetchModel(modelUri);
 
-        const tdUri= "./test/thing-model/tmodels/placeholderExtension/thingExtended.jsonld";
+        const tdUri = "./test/thing-model/tmodels/placeholderExtension/thingExtended.jsonld";
         const td = await fs.readFile(tdUri, "utf-8");
         const tdJson = JSON.parse(td);
 
@@ -459,7 +459,7 @@ class ThingModelHelperTest {
             THING_MODEL: "extended_thing",
             THING_UUID_V4: "bf2c24bc-9232-454d-ac17-90feb3647b71",
             MQTT_BROKER_ADDR: "example.org:1883",
-        }
+        };
 
         const options: CompositionOptions = {
             map,


### PR DESCRIPTION
Change ThingModelHelpers.fetchAffordances() to take CompositionOptions as input and propagate them to successive _getPartialTDs calls.

This allows for correct replacement of placeholders via the CompositionOptions map in Thing Models fetched via fetchAffordances.

## Example use case:
Base thing model with placeholders 
```
{
    "@context": [
        "https://www.w3.org/2022/wot/td/v1.1"
    ],
    "@type": "tm:ThingModel",
    "title": "base_thing",
    "version": {
        "model": "0.0.1"
    },
    "id": "urn:uuid:{{THING_UUID_V4}}",
    "description": "The most basic thing",
    "securityDefinitions": {
        "nosec_sc": {
            "scheme": "nosec"
        }
    }
}
```

Another thing model that extends the base thing model
```
{
    "@context": [
        "https://www.w3.org/2022/wot/td/v1.1"
    ],
    "@type": "tm:ThingModel",
    "title": "extended_thing",
    "version": {
        "model": "0.0.1"
    },
    "description": "Extends the base thing with some properties",
    "links": [{
        "rel": "tm:extends",
        "href": "file://./test/thing-model/tmodels/placeholderExtension/BaseThingWithPlaceholder.tm.jsonld",
        "type": "application/tm+json"
    }],
    "properties": {
        "some_property": {
            "type": "string",
            "description": "Some property",
            "forms": [{
                "href": "mqtt://{{MQTT_BROKER_ADDR}}",
                "mqv:topic": "{{THING_MODEL}}/{{THING_UUID_V4}}/properties/some_property",
                "op": "observeproperty",
                "mqv:qos": 1,
                "mqv:retain": false,
                "contentType": "application/json"
            }]
        }
    }
}
```

map: 
```
const map = {
    THING_MODEL: "extended_thing",
     THING_UUID_V4: "bf2c24bc-9232-454d-ac17-90feb3647b71",
     MQTT_BROKER_ADDR: "example.org:1883"
 }
```

In this scenario, given a valid map, the current implementation will fail to correctly instantiate the partial Thing Description for the "extended_thing" model, as the composition options are not propagated by fetchAffordances() to the following _getPartialTDs() calls.

