### PR TITLE
Adding the new code-gen package

### DIFF
--- a/node/code-gen/.env.template
+++ b/node/code-gen/.env.template
@@ -1,0 +1,6 @@
+GEMINI_API_KEY = "add your gemini api here"
+GEMINI_MODEL = "add your gemini model here"
+GROQ_API_KEY = "add your groq api here"
+GROQ_MODEL = "add your groq model here"
+OPENAI_API_KEY = "add your openai api here"
+OPENAI_MODEL = "add your openai model here"

--- a/node/code-gen/.gitattributes
+++ b/node/code-gen/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/node/code-gen/.gitignore
+++ b/node/code-gen/.gitignore
@@ -1,0 +1,11 @@
+# Ignore node_modules directory
+node_modules
+
+# Ignore environment variable files
+.env
+
+# Ignore the dist directory
+dist
+
+# Ignore the generator output directory
+generator-output

--- a/node/code-gen/README.md
+++ b/node/code-gen/README.md
@@ -1,0 +1,164 @@
+# WoT Code Generator
+
+This package provides a client code generator for Thing Descriptions (TDs), capable of producing either deterministic or AI-generated code.
+
+It can be used as a standalone package or via a command-line interface (CLI).
+
+## Usage
+
+Install this package via NPM:
+
+```bash
+npm install @thingweb/code-gen
+```
+
+Alternatively, clone the repository, navigate to node/code-gen, and install dependencies:
+
+```bash
+git clone https://github.com/eclipse-thingweb/td-tools
+cd node/code-generator
+npm install
+```
+
+## Code Generator CLI
+
+A command-line interface tool for generating protocol-specific code snippets from Web of Things (WoT) Thing Descriptions (TDs).
+
+### Features
+
+- Interactive and one-line command modes
+- Deterministic Support for multiple programming languages and libraries
+- AI-powered code generation for not yet available cases (ChatGPT, Gemini, Llama)
+- Flexible TD input (file or text editor)
+- Multiple output options (console of file)
+
+### Installation Steps
+
+1. Clone the repository using Git:
+
+    ```bash
+    git clone https://github.com/SergioCasCeb/code-generator.git
+    ```
+
+2. Navigate to the project directory:
+
+    ```bash
+    cd code-generator
+    ```
+
+3. Install all project dependencies:
+
+    ```bash
+    npm install
+    ```
+
+4. Link the project globally to make the `generate-code` command available on your system:
+
+    ```bash
+    npm link
+    ```
+
+    This allows you to run the `generate-code` command anywhere in your terminal.
+
+### Usage
+
+The CLI can be used in two modes: interactive and one-line command
+
+#### Interactive Mode
+
+Run the CLI in interactive mode:
+
+```bash
+generate-code -i
+```
+
+The interactive mode guides you through the following steps:
+
+1. Choose TD input method (file or text editor)
+2. Select an affordance
+3. Choose a form index (optional)
+4. Select and operation
+5. Choose between deterministic or AI-powered generation (If a protocol is not supported AI is selected by default)
+6. Select programming language
+7. Select library
+8. Choose output type (console or file)
+
+*Finally, after generating the code, the interactive mode also returns the equivalent options to run the CLI in the one-line mode.*
+
+#### One-line Command Mode
+
+For automated workflows, use the one-line command mode:
+
+#### Options
+
+- `-i, --interactive`: Run CLI in interactive mode
+- `-t, --td <path>`: Path to the Thing Description file
+- `-a, --affordance <name>`: Affordance to use
+- `-f, --form-index <index>`: Form index to use
+- `-o, --operation <name>`: Operation to perform
+- `-l, --language <name>`: Programming language
+- `-L, --library <name>`: Library to use
+- `--ai`: Use AI generation
+- `--tool <name>`: AI tool to use (ChatGPT, Gemini, Llama)
+- `-O, --output <type>`: Output type (console or file)
+- `-h, --help`: Display help information
+- `-V, --version`: Display version number
+
+#### Examples
+
+Generate code utilizing the deterministic generator
+
+```bash
+generate-code --td ./calculator.td.jsonld -a result -f 0 -o readproperty -l javascript -L node-wot -O console
+```
+
+Generate code utilizing the AI generator
+
+```bash
+generate-code --td ./calculator.td.jsonld -a result -f 0 -o readproperty -l javascript -L axios --ai --tool chatgpt -O console
+```
+
+### Supported formats
+
+#### Input files
+
+- JSON (.json)
+- JSON-LD (.jsonld)
+- Text (.txt)
+
+#### Programming Languages and Libraries
+
+Deterministic:
+
+- JavaScript
+    - Fetch
+    - node-wot
+    - modbus-serial
+
+- Python
+    - Requests
+
+No restrictions when using AI generation.
+
+### Output
+
+#### Console Output
+
+The generated code is printed directly to the console in simple text format. AI generation adds markdown syntax to the code.
+
+#### File Output
+
+A new folder called `generator-ouput` is created within the project and the generated code is saved to a file with the following naming convention `<affordance>_<operation>_<language>.<extension>`
+
+## Contributing
+
+The deterministic code generation uses `handlebars` templates and protocol-specific helpers for correct compilation.
+
+To contribute new templates:
+
+1. Submit a PR containing only the template in the respective folder.
+2. Test it within the code generator.
+3. If protocol-specific logic is required, add the necessary helper functions in the respective folder along with documentation.
+4. Finally, submit a final PR including any updates or additions to the code-generator, the `handlebars` helpers, etc.
+
+We welcome contributions that expand the supported protocols and improve the overall code generation!

--- a/node/code-gen/README.md
+++ b/node/code-gen/README.md
@@ -37,13 +37,13 @@ A command-line interface tool for generating protocol-specific code snippets fro
 1. Clone the repository using Git:
 
     ```bash
-    git clone https://github.com/SergioCasCeb/code-generator.git
+    git clone https://github.com/eclipse-thingweb/td-tools
     ```
 
 2. Navigate to the project directory:
 
     ```bash
-    cd code-generator
+    cd node/code-gen
     ```
 
 3. Install all project dependencies:
@@ -156,7 +156,7 @@ The deterministic code generation uses `handlebars` templates and protocol-speci
 
 To contribute new templates:
 
-1. Submit a PR containing only the template in the respective folder.
+1. Submit a PR containing only the template in the respective folder, as well as updating the `templates-paths.json` file.
 2. Test it within the code generator.
 3. If protocol-specific logic is required, add the necessary helper functions in the respective folder along with documentation.
 4. Finally, submit a final PR including any updates or additions to the code-generator, the `handlebars` helpers, etc.

--- a/node/code-gen/bin/cli.js
+++ b/node/code-gen/bin/cli.js
@@ -1,0 +1,592 @@
+#!/usr/bin/env node
+const { Command } = require("commander");
+const chalk = require("chalk");
+const { input, select, editor } = require('@inquirer/prompts');
+const { createSpinner } = require('nanospinner');
+const { addDefaults } = require('@thing-description-playground/defaults');
+const tdValidator = require('@thing-description-playground/core').tdValidator;
+const { generateCode } = require('../src/lib/code-generator.js');
+const { getTDProtocols, getAvailableLanguages, getAvailableLibraries, getAffordanceType, generateFile, parseTD, getTDAffordances, getFormIndexes, getOperations } = require('../src/util/util.js');
+const fs = require('fs');
+const path = require("path");
+const dotenv = require('dotenv');
+dotenv.config();
+
+/**
+ * Provide a user friendly message when the user exits the program and throw an error if the reason for the exit is not an ExitPromptError
+ */
+process.on('uncaughtException', (error) => {
+    if (error instanceof Error && error.name === 'ExitPromptError') {
+        console.log(chalk.yellow('\nThe Code Generator has been exited!'));
+        process.exit(1);
+    } else {
+        throw error;
+    }
+});
+
+
+/**************************/
+/* One-line CLI logic **/
+/**************************/
+const program = new Command();
+
+program
+    .name("generate-code")
+    .description("Generate protocol specific code snippets for Thing Descriptions")
+    .version('1.0.0')
+
+program
+    .option("-i, --interactive", "The interactive mode", false)
+    .option("-t, --td <path>", "Path to the Thing Description file")
+    .option("-a, --affordance <name>", "Affordance to use")
+    .option("-f, --form-index <index>", "Form index to use")
+    .option("-o, --operation <name>", "Operation to perform")
+    .option("-l, --language <name>", "Programming language")
+    .option("-L, --library <name>", "Library to use")
+    .option("--ai", "Use AI generation", false)
+    .option("--tool <name>", "AI tool to use (ChatGPT, Gemini, Llama)")
+    .option("-O, --output <type>", "Output type (console or file)", "console")
+    .action((options) => {
+        if (options.interactive) {
+            runInteractiveCLI();
+        } else {
+
+            const requiredOptions = ['td', 'affordance', 'operation', 'language', 'library'];
+            const missingOptions = requiredOptions.filter((option) => !options[option]);
+
+            if (missingOptions.length > 0) {
+                console.error("Error: " + chalk.red(`Missing required options: ${missingOptions.join(', ')}`));
+                program.help();
+                program.exit(1);
+            }
+
+            runOneLineCLI(options);
+        }
+    });
+
+program.parse(process.argv);
+
+/**
+ * Run the one-line CLI
+ * @param { Object } options 
+ */
+async function runOneLineCLI(options) {
+    const spinner = createSpinner("Generating code...").start();
+    try {
+        const fileType = path.extname(options.td);
+
+        if (fileType !== '.json' && fileType !== '.jsonld' && fileType !== '.txt') {
+            throw new Error("Invalid file format! Please select a JSON, JSONLD or TXT file.");
+        }
+
+        const fileContent = fs.readFileSync(options.td, 'utf8');
+        const parsedTD = parseTD(fileContent);
+
+        await validateTD(parsedTD);
+
+        const generatorInputs = {
+            td: parsedTD,
+            affordance: options.affordance,
+            formIndex: options.formIndex,
+            operation: options.operation,
+            programmingLanguage: options.language.toLowerCase(),
+            library: options.library.toLowerCase()
+        };
+
+        //Get the AI tool if the generator type is AI
+        if (options.ai) {
+
+            //Get the AI configuration based on the selected AI tool
+            if (options.tool == "chatgpt") {
+                aiConfig = {
+                    apiKey: process.env.OPENAI_API_KEY,
+                    enpoint: process.env.OPENAI_ENDPOINT,
+                    model: process.env.OPENAI_MODEL
+                }
+            }
+            else if (options.tool == "gemini") {
+                aiConfig = {
+                    apiKey: process.env.GEMINI_API_KEY,
+                    model: process.env.GEMINI_MODEL
+                }
+            }
+            else {
+                aiConfig = {
+                    apiKey: process.env.GROQ_API_KEY,
+                    model: process.env.GROQ_MODEL
+                }
+            }
+        }
+
+        const outputCode = await generateCode(generatorInputs, options.ai, options.tool ? options.tool : null);
+        spinner.success(`Success: ${chalk.green('Code generated successfully!\n')}`);
+
+        if (options.output === 'file') {
+            generateFile(options.affordance, options.operation, options.language, outputCode);
+        } else {
+            console.log(outputCode);
+        }
+    } catch (error) {
+        spinner.error("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+
+
+/**************************/
+/* Interactive CLI Logic **/
+/**************************/
+
+/**
+ * Get the type of input for the TD
+ * @returns { String } tdInput
+ */
+async function tdInputType() {
+    const tdInput = await select({
+        message: 'How would you like to input your TD?',
+        choices: [
+            {
+                name: 'File',
+                value: 'file',
+            },
+            {
+                name: 'Text',
+                value: 'text',
+            },
+        ],
+    });
+
+    return tdInput;
+}
+
+/**
+ * Add defaults and validate the TD
+ * @param { Object } td 
+ * @returns { Boolean }
+ */
+async function validateTD(td) {
+    //add defaults to the td, to assure that all forms have an operation and contentType
+    addDefaults(td);
+
+    // Store log messages, to show only if the validation fails
+    let logMessages = [];
+
+    // Push log messages to the logMessages array
+    function validationLog(msg) {
+        logMessages.push(msg);
+    }
+
+    //run the tdValidator function
+    const validation = await tdValidator(JSON.stringify(td), validationLog, { checkDefaults: true, checkJsonLd: true, checkTmConformance: false });
+
+    //check al the report values to see if the validation passed
+    const validTD = Object.values(validation.report).every(value => value !== 'failed');
+
+    if (validTD) {
+        return true;
+    } else {
+        throw new Error('The Thing Description is invalid! Please check the following errors:\n' + logMessages.join('\n'));
+    }
+}
+
+/**
+ * Get the TD from a file
+ * @returns { Object } parsedTD
+ */
+async function getTDFile() {
+
+    const fileSelectorModule = await import('inquirer-file-selector');
+    const fileSelector = fileSelectorModule.default;
+    const filePath = await fileSelector({
+        message: 'Select the path to your TD file:',
+        basePath: process.cwd(),
+        type: 'file',
+        allowCancel: true,
+        cancelText: 'Exited file selection',
+    });
+
+    try {
+        const fileType = path.extname(filePath);
+
+        if (fileType !== '.json' && fileType !== '.jsonld' && fileType !== '.txt') {
+            console.log(chalk.red("Invalid file format! Please select a JSON, JSONLD or TXT file."));
+            process.exit(1);
+        }
+
+        const fileContent = fs.readFileSync(filePath, 'utf8');
+        const parsedTD = parseTD(fileContent);
+        await validateTD(parsedTD);
+        return parsedTD;
+
+
+    } catch (error) {
+        console.log("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+/**
+ * Get the TD from a text editor
+ * @returns { Object } parsedTD
+ */
+async function getTDEditor() {
+
+    const td = await editor({
+        message: 'Enter your TD here:',
+    });
+
+    try {
+        const parsedTD = parseTD(td);
+        await validateTD(parsedTD);
+        return parsedTD;
+    }
+    catch (error) {
+        console.log("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+/**
+ * Get all the affordance options from the TD and return the selected affordance
+ * @param { Object } td 
+ * @returns { String } affordance
+ */
+async function getAffordanceOptions(td) {
+    try {
+        const affordanceOptions = getTDAffordances(td);
+
+        const affordance = await select({
+            message: 'Select an affordance:',
+            choices: affordanceOptions,
+        });
+
+        return affordance;
+
+    } catch (error) {
+        console.log("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+/**
+ * Get all the forms available for the selected affordance and return the selected form index
+ * @param { Object } td 
+ * @param { String } affordanceType 
+ * @param { String } affordance 
+ * @returns { String } formIndex
+ */
+async function getFormIndex(td, affordanceType, affordance) {
+    try {
+        const availableForms = getFormIndexes(td, affordanceType, affordance) || [];
+        const emptyForm = [{ name: 'None', value: null, description: "Do not want to specify any form!" }];
+
+        const formIndexOptions = [
+            ...emptyForm,
+            ...availableForms.map((index) => { return { name: index, value: index } })
+        ];
+
+        const formIndex = await select({
+            message: `Select a form index:`,
+            choices: formIndexOptions,
+        });
+
+        return formIndex;
+
+    } catch (error) {
+        console.log("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+/**
+ * Get the possbile operations for the selected affordance and return the selected operation
+ * @param { String } affordanceType 
+ * @returns { String } operation
+ */
+async function getOperation(td, affordanceType, affordance, formIndex) {
+
+    try {
+        const availableOperations = getOperations(td, affordanceType, affordance, formIndex);
+
+        if (availableOperations.length === 1) {
+            console.log(`${chalk.green.bold('✓')} ${chalk.bold('Select an operation:')} ${chalk.cyan(availableOperations[0])}`);
+            return availableOperations[0];
+        }
+        else {
+            const operation = await select({
+                message: 'Select an operation:',
+                choices: availableOperations,
+            });
+
+            return operation;
+        }
+
+    } catch (error) {
+        console.log("Error: " + chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+/**
+ * Get the generator type
+ * @returns { Boolean } isAI
+ */
+async function getGeneratorType() {
+    const isAI = await select({
+        message: 'Select a generator type:',
+        choices: [
+            { name: 'Deterministic', value: false },
+            { name: 'AI', value: true },
+        ],
+    });
+
+    return isAI;
+}
+
+/**
+ * Get the AI tool
+ * @returns { String } aiTool
+ */
+async function getAITool() {
+    const aiTool = await select({
+        message: 'Select an AI tool:',
+        choices: [
+            { name: 'ChatGPT', value: "chatgpt" },
+            { name: 'Gemini', value: "gemini" },
+            { name: 'Llama', value: "llama" },
+        ],
+    });
+
+    return aiTool;
+}
+
+/**
+ * Get the available programming languages based on the selected TD protocols and return the selected programming language.
+ * If the generator type is AI, get the programming language as a text input
+ * @param { Boolean } isAI 
+ * @param { Array } tdProtocols 
+ * @returns { Array } [programmingLanguage, languageList]
+ */
+async function getProgrammingLanguage(isAI, tdProtocols) {
+
+    if (isAI) {
+        const programmingLanguage = await input({
+            type: 'text',
+            message: 'Enter a programming language:',
+        });
+
+        return [programmingLanguage, null];
+    } else {
+        const languagesList = getAvailableLanguages(tdProtocols);
+        let availableLanguages = [];
+
+        languagesList.forEach((language) => {
+            availableLanguages.push(...Object.keys(language))
+        })
+
+        availableLanguages = [...new Set(availableLanguages)];
+
+        if (availableLanguages && availableLanguages.length > 0) {
+            const programmingLanguage = await select({
+                message: 'Enter a programming language:',
+                choices: availableLanguages,
+            });
+
+            return [programmingLanguage, languagesList];
+        } else {
+            console.log(chalk.red('No programming languages available!'));
+            process.exit(1);
+        }
+    }
+}
+
+/**
+ * Get the available libraries based on the selected programming language and return the selected library.
+ * If the generator type is AI, get the library as a text input
+ * @param { Boolean } isAI 
+ * @param { String } programmingLanguage 
+ * @param { Array } languageList 
+ * @returns { String } library
+ */
+async function getLibrary(isAI, programmingLanguage, languageList) {
+
+    if (isAI) {
+        const library = await input({
+            type: 'text',
+            message: 'Enter a library:',
+        });
+
+        return library;
+    }
+    else {
+        const availableLibraries = getAvailableLibraries(programmingLanguage, languageList);
+
+        if (availableLibraries && availableLibraries.length > 0) {
+            const library = await select({
+                message: 'Select a library:',
+                choices: availableLibraries,
+            });
+
+            return library;
+        } else {
+            console.log(chalk.red('No libraries available!'));
+            process.exit(1);
+        }
+    }
+}
+
+/**
+ * Get the desired output type
+ * @returns { String } output
+ */
+async function getOutputType() {
+    const output = await select({
+        message: 'How would you like to output the code?',
+        choices: [
+            {
+                name: 'Console',
+                value: 'console',
+            },
+            {
+                name: 'File',
+                value: 'file',
+            },
+        ],
+    });
+
+    return output;
+}
+
+/**
+ * Return the CLI options for the one-line CLI
+ * @param { Object } generatorInputs 
+ * @param { Boolean } isAI 
+ * @param { String } aiTool 
+ * @param { String } outputType 
+ * @returns { String } cliOptionsString
+ */
+function returnCLIOptions(generatorInputs, isAI, aiTool, outputType) {
+    const cliOptionsString = `generate-code ${chalk.gray('--td')} [path to TD] ${chalk.gray('--affordance')} ${generatorInputs.affordance} ${generatorInputs.formIndex !== null ? chalk.gray('--form-index ') + generatorInputs.formIndex : ''} ${chalk.gray('--operation')} ${generatorInputs.operation} ${chalk.gray('--language')} ${generatorInputs.programmingLanguage} ${chalk.gray('--library')} ${generatorInputs.library} ${isAI ? chalk.gray('--ai --tool ') + aiTool : ''} ${chalk.gray('--output')} ${outputType}`;
+
+    return cliOptionsString;
+}
+
+/**
+ * Main function to run the interactive CLI
+ */
+async function runInteractiveCLI() {
+
+    //Declare all necessary variables
+    let inputTD;
+    let affordance;
+    let formIndex;
+    let operation;
+    let aiConfig;
+    let isAI = false;
+    let aiTool;
+    let tdProtocols;
+    let programmingLanguage;
+    let languageList;
+    let library;
+    let outputType = 'console';
+
+    //Get the type of input for the TD
+    const inputType = await tdInputType();
+
+    //Get the TD based on the input type
+    if (inputType === 'file') {
+        inputTD = await getTDFile();
+    } else {
+        inputTD = await getTDEditor();
+    }
+
+    //Get the affordance
+    affordance = await getAffordanceOptions(inputTD);
+
+    //Get the affordance type
+    const affordanceType = getAffordanceType(inputTD, affordance);
+
+    //Get the form index
+    formIndex = await getFormIndex(inputTD, affordanceType, affordance);
+
+    //Get the operation
+    operation = await getOperation(inputTD, affordanceType, affordance, formIndex);
+
+    //Get the TD protocols
+    tdProtocols = getTDProtocols(JSON.stringify(inputTD));
+
+    //Do not ask for the generator type if the TD protocols are not available in the templates
+    if (tdProtocols) {
+        //Get the generator type
+        isAI = await getGeneratorType();
+    } else {
+        isAI = true;
+    }
+
+    //Get the AI tool if the generator type is AI
+    if (isAI) {
+        aiTool = await getAITool();
+
+        //Get the AI configuration based on the selected AI tool
+        if (aiTool == "chatgpt") {
+            aiConfig = {
+                apiKey: process.env.OPENAI_API_KEY,
+                enpoint: process.env.OPENAI_ENDPOINT,
+                model: process.env.OPENAI_MODEL
+            }
+        }
+        else if (aiTool == "gemini") {
+            aiConfig = {
+                apiKey: process.env.GEMINI_API_KEY,
+                model: process.env.GEMINI_MODEL
+            }
+        }
+        else {
+            aiConfig = {
+                apiKey: process.env.GROQ_API_KEY,
+                model: process.env.GROQ_MODEL
+            }
+        }
+    }
+
+    //Get the programming language
+    [programmingLanguage, languageList] = await getProgrammingLanguage(isAI, tdProtocols);
+
+    //Get the library
+    library = await getLibrary(isAI, programmingLanguage, languageList);
+
+    //Get the output type
+    outputType = await getOutputType();
+
+    //Prepare the inputs for the code generator and generate the code
+    const generatorInputs = {
+        td: inputTD,
+        affordance: affordance,
+        formIndex: formIndex,
+        operation: operation,
+        programmingLanguage: programmingLanguage,
+        library: library
+    };
+
+    //Start the loading spinner
+    const spinner = createSpinner('Generating Code...').start();
+
+    try {
+        //Generate the code and stop the spinner if successful
+        const outputCode = await generateCode(generatorInputs, isAI, aiTool ? aiTool : null, aiConfig);
+        spinner.success(`Success: ${chalk.green('Code generated successfully!')}`)
+        console.log(`${chalk.bold.yellow('CLI Options:')} ${returnCLIOptions(generatorInputs, isAI, aiTool, outputType)}`);
+        if (outputType === 'file') {
+            generateFile(affordance, operation, programmingLanguage, outputCode);
+        } else {
+            console.log(`\n${outputCode}`);
+        }
+
+    } catch (error) {
+        //Stop the spinner and display the error message
+        spinner.error(`Error: ${chalk.red(error.message)}`);
+        process.exit(1);
+    }
+
+}

--- a/node/code-gen/package.json
+++ b/node/code-gen/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "@thingweb/code-gen",
+    "version": "1.0.0",
+    "description": "This package provides a client code generator for the Thing Descriptions.",
+    "main": "./src/lib/code-generator.js",
+    "bin": {
+      "generate-code": "./bin/cli.js"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/eclipse-thingweb/td-tools.git",
+      "directory": "node/code-gen"
+    },
+    "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
+    "license": "EPL-2.0 OR W3C-20150513",
+    "bugs": {
+      "url": "https://github.com/eclipse-thingweb/code-gen/issues"
+    },
+    "homepage": "https://github.com/eclipse-thingweb/code-gen#readme",
+    "dependencies": {
+      "@google/generative-ai": "^0.21.0",
+      "@inquirer/prompts": "^7.2.3",
+      "@thing-description-playground/core": "^1.4.0",
+      "@thing-description-playground/defaults": "^1.4.0",
+      "@thingweb/td-utils": "^1.0.0",
+      "chalk": "^4.1.2",
+      "commander": "^13.1.0",
+      "dotenv": "^16.4.7",
+      "groq-sdk": "^0.12.0",
+      "handlebars": "^4.7.8",
+      "inquirer-file-selector": "^0.6.1",
+      "json-schema-faker": "^0.5.8",
+      "mustache": "^4.2.0",
+      "nanospinner": "^1.2.2",
+      "openai": "^4.79.1",
+      "url-toolkit": "^2.2.5"
+    }
+  }
+  

--- a/node/code-gen/src/ai-generators/chatgpt-generator.js
+++ b/node/code-gen/src/ai-generators/chatgpt-generator.js
@@ -1,0 +1,35 @@
+const { OpenAI } = require("openai");
+
+/**
+ * Generate code using the ChatGPT API
+ * @param { Object } generatorInputs 
+ * @returns { Promise<String> } The generated code
+ */
+async function generateChatGPTCode(generatorInputs, aiConfig) {
+    const apiKey = aiConfig.apiKey;
+
+    const client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+
+
+    const systemInstructions = "You are an expert senior IoT and WoT developer. Based on the provided JSON object, generate protocol-specific code that follows best practices using the specified programming language and library. Do not include any extra explanations, or descriptions only the code. The input includes a Thing Description (TD) with properties, actions, and events, from which you must use the specified affordance. Implement the operation as described, using the specified form or the default if no form index is provided. If the operation is observeproperty or subscribeevent assume the user also wants a way to unobserve and/or unsubscribe. The programming language and library should be adhered to in the generated code. Focus solely on producing the required code to perform the operation based on these inputs.";
+
+    const response = await client.chat.completions.create({
+        model: aiConfig.model ? aiConfig.model : "gpt-4o",
+        messages: [
+            { role: "system", content: systemInstructions },
+
+            { role: "user", content: generatorInputs },
+        ],
+
+        // temperature: 0.7,
+        // top_p: 0.95,
+        // frequency_penalty: 0,
+        // presence_penalty: 0,
+        // stop: null
+    });
+
+    return response.choices[0].message.content;
+}
+
+//Export the function to be used in the main script
+module.exports = generateChatGPTCode;

--- a/node/code-gen/src/ai-generators/gemini-generator.js
+++ b/node/code-gen/src/ai-generators/gemini-generator.js
@@ -1,0 +1,28 @@
+const { GoogleGenerativeAI } = require("@google/generative-ai");
+
+/**
+ * Generate code using the Gemini API
+ * @param { Object } generatorInputs 
+ * @returns { Promise<String> } The generated code
+ */
+async function generateGeminiCode(generatorInputs, aiConfig) {
+
+    const genAI = new GoogleGenerativeAI(aiConfig.apiKey);
+
+    const systemInstructions = "You are an expert senior IoT and WoT developer. Based on the provided JSON object, generate protocol-specific code that follows best practices using the specified programming language and library. Do not include any extra explanations, or descriptions only the code. The input includes a Thing Description (TD) with properties, actions, and events, from which you must use the specified affordance. Implement the operation as described, using the specified form or the default if no form index is provided. If the operation is observeproperty or subscribeevent assume the user also wants a way to unobserve and/or unsubscribe. The programming language and library should be adhered to in the generated code. Focus solely on producing the required code to perform the operation based on these inputs.";
+
+
+    const model = genAI.getGenerativeModel({
+        model: aiConfig.model ? aiConfig.model : "gemini-1.5-flash",
+        systemInstruction: systemInstructions
+    })
+
+    const prompt = generatorInputs;
+
+    const result = await model.generateContent(prompt);
+
+    return result.response.text()
+}
+
+//Export the function to be used in the main script
+module.exports = generateGeminiCode;

--- a/node/code-gen/src/ai-generators/llama-generator.js
+++ b/node/code-gen/src/ai-generators/llama-generator.js
@@ -1,0 +1,32 @@
+const { Groq } = require("groq-sdk");
+
+/**
+ * Generate code using the Llama API
+ * @param { Object } generatorInputs 
+ * @returns { Promise<String> } The generated code
+ */
+async function generateLlamaCode(generatorInputs, aiConfig) {
+    const groq = new Groq({ apiKey: aiConfig.apiKey, dangerouslyAllowBrowser: true});
+
+    const systemInstructions = "You are an expert senior IoT and WoT developer. Based on the provided JSON object, generate protocol-specific code that follows best practices using the specified programming language and library. Do not include any extra explanations, or descriptions only the code. The input includes a Thing Description (TD) with properties, actions, and events, from which you must use the specified affordance. Implement the operation as described, using the specified form or the default if no form index is provided. If the operation is observeproperty or subscribeevent assume the user also wants a way to unobserve and/or unsubscribe. The programming language and library should be adhered to in the generated code. Focus solely on producing the required code to perform the operation based on these inputs.";
+
+    const chatCompletion = await groq.chat.completions.create({
+        messages: [
+            {
+                role: "user",
+                content: systemInstructions,
+            },
+            {
+                role: "user",
+                content: generatorInputs,
+            },
+        ],
+        model: aiConfig.model ? aiConfig.model : "llama3-8b-8192",
+    });
+
+    // Print the completion returned by the LLM.
+    return chatCompletion.choices[0]?.message?.content || "";
+}
+
+//Export the function to be used in the main script
+module.exports = generateLlamaCode;

--- a/node/code-gen/src/helpers/protocols/httpHelpers.js
+++ b/node/code-gen/src/helpers/protocols/httpHelpers.js
@@ -1,0 +1,70 @@
+/**
+ * All HTTP protocol specific helper functions are defined in this file
+ */
+
+
+/**
+ * Get the subprotocol from the form, if it is not present, return sse as the default subprotocol
+ * @param { Object } form 
+ * @param { String } operation 
+ * @returns { String } - the subprotocol to be used
+ */
+function getSubprotocol(form, operation) {
+    if(form["subprotocol"]) {
+        return form["subprotocol"];
+    }else {
+        if(operation == "observeproperty" || operation == "unobserveproperty" || operation == "subscribeevent" || operation == "unsubscribeevent") {
+            return 'sse';
+        }else{
+            return null;
+        }
+    }
+}
+
+/**
+ * Get the htv:methodName from the form to return the required method, or
+ * return the default method for the specified operation
+ * @param { Object } form 
+ * @param { String } operation 
+ * @returns { String } - the method to be used
+ */
+function getMethod(form, operation) {
+
+    if(form["htv:methodName"]){
+        return form["htv:methodName"];
+    }else{
+        if(operation == "observerproperty" || operation == "unobserveproperty" || operation == "subscribeevent" 
+            || operation == "unsubscribeevent" || operation == "readproperty") {
+            return "GET";
+        }
+        else if(operation == "invokeaction") {
+            return "POST";
+        }
+        else if(operation == "writeproperty") {
+            return "PUT";
+        }
+        else {
+            return null;
+        }
+    }
+}
+
+/**
+ * Get the content type from the form, if it is not present, return application/json as the default content type
+ * @param { Object } form 
+ * @returns { String } - the content type to be used
+ */
+function getContentType(form) {
+    if(form["contentType"]){
+        return form["contentType"];
+    }else{
+        return "application/json";
+    }
+}
+
+// Export all http helper functions
+module.exports = {
+    getSubprotocol,
+    getMethod,
+    getContentType
+}

--- a/node/code-gen/src/helpers/protocols/modbusHelpers.js
+++ b/node/code-gen/src/helpers/protocols/modbusHelpers.js
@@ -1,0 +1,160 @@
+/**
+ * All Modbus protocol specific helper functions are defined in this file.
+ */
+const URLToolkit = require('url-toolkit');
+
+/**
+ * get the IP from the URL
+ * @param { String } URL 
+ * @returns { String } - IP address
+ */
+function getIP(URL) {
+    const urlComponents = URLToolkit.parseURL(URL);
+    const ipMatch = urlComponents["netLoc"].match(/\/\/([\d.]+):/);
+
+    if(ipMatch) {
+        return ipMatch[1];
+    }else {
+        throw new Error("IP was not found in the URL");
+    }
+}
+
+/**
+ * Get the Port from the URL
+ * @param { String } URL 
+ * @returns { String } - Port number
+ */
+function getPort(URL) {
+    const urlComponents = URLToolkit.parseURL(URL);
+    const portMatch = urlComponents["netLoc"].match(/:(\d+)$/);
+    
+    if(portMatch) {
+        return portMatch[1];
+    }else {
+        throw new Error("Port was not found in the URL");
+    }
+}
+
+/**
+ * Get the UnitID from the URL
+ * @param { String } URL 
+ * @returns { String } unitID - the unitID specified in the URL
+ */
+function getUnitID(URL) {
+    const urlComponents = URLToolkit.parseURL(URL);
+    const unitID = urlComponents["path"].replace("/", "");
+
+    if(unitID) {
+        return unitID;
+    }
+    else {
+        throw new Error("UnitID was not found in the URL");
+    }  
+}
+
+/**
+ * Get the Address from the URL parameters
+ * @param { String } URL 
+ * @returns { String } address - the address specified in the parameters
+ */
+function getAddress(URL) {
+    const urlComponents = URLToolkit.parseURL(URL);
+    const params = new URLSearchParams(urlComponents["query"]);
+
+    const address = params.get('address');
+
+    if(address) {
+        return address;
+    }
+    else {
+        throw new Error("Address was not specified in the URL");
+    }
+}
+
+/**
+ * Get the quantity/length from the URL parameters
+ * @param { String } URL 
+ * @returns { String } quantity - the quantity specified in the parameters
+ */
+function getQuantity(URL) {
+    const urlComponents = URLToolkit.parseURL(URL);
+    const params = new URLSearchParams(urlComponents["query"]);
+
+    const quantity = params.get('quantity');
+
+    if(quantity) {
+        return quantity;
+    }
+    else {
+        throw new Error("Quantity was not specified in the URL");
+    }
+}
+
+/**
+ * Get the modbus polling time specified in the form
+ * @param { Object } form 
+ * @returns { String } pollingTime - the polling time specified in the form
+ */
+function getPollingTime(form) {
+    const pollingTime = form["modv:pollingTime"];
+
+    return pollingTime ? pollingTime : '500';
+}
+
+/**
+ * Get the modbus function specified in the form, if not specified 
+ * set a default one depending on the operation
+ * @param { Object } form 
+ * @param { String } operation 
+ * @returns { String } modbusFunction - the modbus function to be used
+ */
+function getModbusFunction(form, operation) {
+
+    let modbusFunction;
+
+    const modbusSerialFunctions = {
+        readCoil: 'readCoils',
+        readDiscreteInput: 'readDiscreteInputs',
+        readHoldingRegisters: 'readHoldingRegisters',
+        readInputRegisters: 'readInputRegisters',
+        writeSingleCoil: 'writeCoil',
+        writeSingleHoldingRegister: 'writeRegister',
+        writeMultipleCoils: 'writeCoils',
+        writeMultipleHoldingRegisters: 'writeRegisters'
+    }
+
+    if(form["modv:function"]) {
+        modbusFunction = modbusSerialFunctions[form["modv:function"]];
+    }
+    else {
+        if(operation === 'readproperty') {
+            modbusFunction = 'readDiscreteInputs';
+        }
+        else if(operation === 'writeproperty' || operation === 'invokeaction') {
+            modbusFunction = 'writeCoil';
+        }
+        else if(operation === 'observeproperty' || operation === 'unobserveproperty') {
+            modbusFunction = 'readCoils';
+        }
+        else {
+            return null;
+        }
+    }
+    
+    if(modbusFunction) {
+        return modbusFunction;
+    }else {
+        throw new Error("Not found or wrong Modbus function specified in the TD");
+    }
+}
+
+//Export all the modbus helper functions
+module.exports = {
+    getIP,
+    getPort,
+    getUnitID,
+    getAddress,
+    getQuantity,
+    getPollingTime,
+    getModbusFunction
+}

--- a/node/code-gen/src/helpers/utilHelpers.js
+++ b/node/code-gen/src/helpers/utilHelpers.js
@@ -1,0 +1,100 @@
+/**
+ * All general and reusable utility helper functions are defined in this file.
+ */
+const JSONSchemaFaker = require("json-schema-faker");
+
+/**
+ * Check if two arguments are equal
+ * @param { any } arg1 
+ * @param { any } arg2 
+ * @returns { boolean } - true if equal, false otherwise
+ */
+function equalTo(arg1, arg2) {
+    return arg1 === arg2;
+}
+
+/**
+ * Check if any of the (2 or 3) arguments are true
+ * @param { boolean } arg1 
+ * @param { boolean } arg2 
+ * @param { boolean } arg3 
+ * @returns { boolean } - true if any of the arguments are true, false otherwise
+ */
+function or(arg1, arg2, arg3) {
+    arg1 = arg1 != (true || false) ?  false : arg1;
+    arg2 = arg2 != (true || false) ?  false : arg2;
+    arg3 = arg3 != (true || false) ?  false : arg3;
+    
+    return arg1 || arg2 || arg3;
+}
+
+/**
+ * Join two strings with a space in between
+ * @param { String } arg1 
+ * @param { String } arg2 
+ * @returns { String } - joined string
+ */
+function joinStr(arg1, arg2) {
+    return arg1 + " " + arg2;
+}
+
+/**
+ * transform a string to follow the camelCase convention
+ * @param { String } str 
+ * @returns { String } - string in camelCase
+ */
+function toCamelCase(str) {
+    return str
+        .toLowerCase()
+        .split(" ")
+        .map((word, index) => {
+            return index > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word;
+        })
+        .join(""); 
+}
+
+/**
+* transform a string to follow the snake_case convention
+ * @param { String } str 
+ * @returns { String } - string in snake_case
+ */
+function toSnakeCase(str) {
+    str = str.toLowerCase();
+    return str.split(" ").join("_");  
+}
+
+function toLowerCase(str) {
+    return str.toLowerCase();
+}
+
+/**
+ * Generate a mock input based on the JSON schema in the affordance object
+ * @param { Object } affordanceObject 
+ * @returns testInput - the generated test input
+ */
+function generateTestInput(affordanceObject) {
+    let testInput;
+
+    if(affordanceObject["input"]) {
+        testInput = JSONSchemaFaker.generate(affordanceObject["input"]);
+    }else {
+        testInput = JSONSchemaFaker.generate(affordanceObject);
+    }
+
+    if(typeof testInput === "number" && !Number.isInteger(testInput)) {
+        testInput = parseFloat(testInput.toFixed(2));
+    }
+    
+    return testInput;
+}
+
+// Export all utility functions
+module.exports = {
+    equalTo,
+    or,
+    joinStr,
+    toCamelCase,
+    toSnakeCase,
+    toLowerCase,
+    generateTestInput
+};

--- a/node/code-gen/src/lib/code-generator.js
+++ b/node/code-gen/src/lib/code-generator.js
@@ -1,0 +1,268 @@
+const Handlebars = require('handlebars');
+const helpers = require('../helpers/utilHelpers.js');
+const httpHelpers = require('../helpers/protocols/httpHelpers.js');
+const modbusHelpers = require('../helpers/protocols/modbusHelpers.js');
+const generateChatGPTCode = require('../ai-generators/chatgpt-generator.js');
+const generateGeminiCode = require('../ai-generators/gemini-generator.js');
+const generateLlamaCode = require('../ai-generators/llama-generator.js');
+const URLToolkit = require('url-toolkit');
+const { getAffordanceType } = require('../util/util.js');
+
+//Register all helpers
+const handlebarsHelpers = [helpers, httpHelpers, modbusHelpers];
+
+handlebarsHelpers.forEach(module => {
+    for (const key in module) {
+        Handlebars.registerHelper(key, module[key]);
+    }
+})
+
+/**************************************/
+/*********** Main generator ***********/
+/**************************************/
+
+/**
+ * Main function to generate code based on the user inputs. It also defines whether to generate code using an AI tool or not.
+ * 
+ * @typedef {Object} userInputs
+ * @property {string} programmingLanguage - The programming language to use
+ * @property {string} library - The library to use
+ * @property {Object} td - The Thing Description object
+ * @property {string} affordance - The affordance to use
+ * @property {string} formIndex - The index of the form to use (optional)
+ * @property {string} operation - The operation to perform
+ * 
+ * @typedef {Object} aiConfig
+ * @property {string} apiKey - The API key for the AI tool
+ * @property {string} model - The model to use for the AI tool (optional)
+ * 
+ * @param { userInputs } userInputs - the full object with all the required user inputs
+ * @param { Boolean } generateAI - whether to generate code using an AI tool or not
+ * @param { string } aiTool - the AI tool to use for code generation
+ * @param { aiConfig } aiConfig - the configuration object for the AI tool
+ * 
+ * @returns { String } - the generated code
+ */
+async function generateCode(userInputs, generateAI = false, aiTool, aiConfig) {
+    //Basic input validation check
+    if (!userInputs || (!userInputs.programmingLanguage || !userInputs.library || !userInputs.td || !userInputs.affordance || !userInputs.operation)) {
+        if (!userInputs) {
+            throw new Error("The inputs object is missing");
+        }
+        else if (!userInputs.programmingLanguage) {
+            throw new Error("A programming language must be specified");
+        }
+        else if (!userInputs.library) {
+            throw new Error("A library must be specified");
+        }
+        else if (!userInputs.td) {
+            throw new Error("A Thing Description must be specified");
+        }
+        else if (!userInputs.affordance) {
+            throw new Error("An affordance must be specified");
+        }
+        else if (!userInputs.operation) {
+            throw new Error("An operation must be specified");
+        } else {
+            throw new Error("Invalid or missing inputs");
+        }
+    }
+
+    try {
+        if (generateAI) {
+            if (!aiTool) {
+                throw new Error("For the AI generation, an AI tool must be specified");
+            }
+
+            if (aiTool === "chatgpt") {
+                return generateChatGPTCode(JSON.stringify(userInputs), aiConfig);
+            }
+            else if (aiTool === "gemini") {
+                return generateGeminiCode(JSON.stringify(userInputs), aiConfig);
+            }
+            else if (aiTool === "llama") {
+                return generateLlamaCode(JSON.stringify(userInputs), aiConfig);
+            }
+            else {
+                throw new Error("The specified AI tool is not supported");
+            }
+
+        } else {
+            const template = await getTemplate(userInputs.programmingLanguage, userInputs.library);
+            const templateInputs = await getTemplateInputs(userInputs.td, userInputs.affordance, userInputs.operation, userInputs.formIndex);
+            // Compile the template with the filtered inputs
+            const compiledTemplate = Handlebars.compile(template);
+            return compiledTemplate(templateInputs);
+        }
+
+    } catch (error) {
+        throw new Error(`Failed to generate code: ${error.message}`);
+    }
+}
+
+
+/*******************************/
+/******* Main functions ********/
+/*******************************/
+
+/**
+ * Get the specific template path based on the language and library, and return the file content
+ * @param { String } language 
+ * @param { String } library 
+ * @returns { String } file - the content of the template file
+ */
+async function getTemplate(language, library) {
+    try {
+        const fetchPaths = require('../templates/templates-paths.json');
+
+        language = language.toLowerCase();
+        library = library.toLowerCase();
+
+        const templatePath = Object.values(fetchPaths).find(value =>
+            value[language] && value[language][library]
+        )?.[language]?.[library];
+
+        if (!templatePath) {
+            throw new Error("No available templates for the specified language and/or library");
+        }
+
+        const res = await fetch(`https://raw.githubusercontent.com/eclipse-thingweb/code-gen/refs/heads/main/src/templates/${templatePath}`);
+        const templateContent = await res.text();
+        return templateContent;
+
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            throw new Error('Invalid templates configuration file');
+        }
+        if (error.code === 'ENOENT') {
+            throw new Error(`File not found`);
+        }
+        throw new Error(`An error occurred while getting the template: ${error.message}`);
+    }
+}
+
+/**
+ * Get the required data to work as the inputs for the the code templates
+ * @param { Object } td 
+ * @param { string } affordance 
+ * @param { string } operation 
+ * @param { integer } formIndex 
+ * @returns { Object } templateValues
+ */
+async function getTemplateInputs(td, affordance, operation, formIndex) {
+
+    let templateValues = {
+        "absoluteURL": null,
+        "affordanceType": null,
+        "affordance": affordance,
+        "affordanceObject": null,
+        "form": null,
+        "operation": null,
+    }
+
+    //Check the operation and formIndex to get the inner values of the affordance
+    const affordanceType = getAffordanceType(td, affordance);
+    templateValues.affordanceType = affordanceType;
+
+    const forms = td[affordanceType][affordance]["forms"];
+    const form = getForm(forms, operation, formIndex);
+
+    templateValues.affordanceObject = td[affordanceType][affordance];
+    templateValues.form = form;
+
+    //treat the unsubscribe and unobserve operations as subscribe and observe
+    if (operation === "unsubscribeevent" || operation === "unobserveproperty") {
+        operation = operation.replace("un", "");
+    }
+    templateValues.operation = operation;
+
+    const absoluteURL = getAbsoluteURL(td.base, form["href"]);
+    templateValues.absoluteURL = absoluteURL;
+
+    return templateValues;
+}
+
+/**
+ * Validate that the given operation belongs to the given form. If no form given look for the form with the given operation.
+ * @param { Array } forms 
+ * @param { string } operation 
+ * @param { number } formIndex 
+ * @returns { Object } formToUse
+ */
+function getForm(forms, operation, formIndex) {
+    let formToUse;
+
+    if (!forms) {
+        throw new Error("No forms array was found for the specified affordance");
+    }
+
+    if (forms.length === 0) {
+        throw new Error(`The forms array cannot be empty`);
+    }
+
+    if (formIndex !== null && formIndex !== undefined) {
+        try {
+            const form = forms[formIndex];
+
+            if (typeof form["op"] === 'object' && form["op"].includes(operation)) {
+                formToUse = form;
+            }
+
+            if (typeof form["op"] === 'string' && form["op"] === operation) {
+                formToUse = form;
+            }
+
+        } catch (error) {
+            throw new Error(`The form index ${formIndex} does not exist in the specified affordance`);
+        }
+
+        if (!formToUse) {
+            throw new Error(`The ${operation} operation is not available in the specified form index ${formIndex}`);
+        }
+
+    }
+    else {
+        if (forms.length > 0) {
+            forms.forEach(form => {
+                if (typeof form["op"] === 'object' && form["op"].includes(operation)) {
+                    formToUse = form;
+                }
+
+                if (typeof form["op"] === 'string' && form["op"] === operation) {
+                    formToUse = form;
+                }
+            })
+        }
+
+        if (!formToUse) {
+            throw new Error(`No form was found with the specified ${operation} operation`);
+        }
+    }
+
+    if (formToUse) {
+        return formToUse;
+    } else {
+        return;
+    }
+}
+
+/**
+ * Construct the absolute URL utilizing the base and the individual href from the form
+ * @param { string } baseURL 
+ * @param { string } partialURL 
+ * @returns { string } absoluteURL
+ */
+function getAbsoluteURL(baseURL, partialURL) {
+
+    const base = baseURL ? baseURL : '';
+    const partial = partialURL ? partialURL : '';
+
+    const absoluteURL = URLToolkit.buildAbsoluteURL(base, partial);
+
+    return absoluteURL;
+}
+
+// Export functions
+module.exports = {
+    generateCode
+}

--- a/node/code-gen/src/templates/http/javascript/fetch/template.hbs
+++ b/node/code-gen/src/templates/http/javascript/fetch/template.hbs
@@ -1,0 +1,115 @@
+{{#if (equalTo (getSubprotocol form operation) "sse")}}
+import { EventSource } from 'eventsource';
+{{else}}
+import fetch from 'node-fetch';
+{{/if}}
+
+const URL = "{{absoluteURL}}";
+
+{{!-- Start by checking for observation/subscription --}}
+{{#if (getSubprotocol form operation)}}
+{{!--if the subprotocol is sse return the following code --}}
+{{#if (equalTo (getSubprotocol form operation) "sse")}}
+function {{toCamelCase (joinStr operation affordance)}}() {
+    const eventSource = new EventSource(URL);
+
+    eventSource.onopen = () => {
+        console.log("Connected Successfully");
+    };
+
+    eventSource.onmessage = (e) => {
+        try {
+            console.log("{{affordance}}: ", JSON.parse(e.data));
+        } catch (error) {
+            console.error('Error with {{affordance}}:', error);
+        }
+    };
+
+    eventSource.onerror = (error) => {
+        console.error('Error with {{affordance}}:', error);
+    };
+
+    return {
+        unsubscribe: () => {
+            eventSource.close();
+        }
+    };
+}
+
+const event = {{toCamelCase (joinStr operation affordance)}}();
+
+//Disconnect after 10 seconds
+setTimeout(() => {
+    event.unsubscribe();
+    console.log("Disconnected");
+}, 10000);
+{{/if}}
+{{!--if the subprotocol is longpoll return the following code --}}
+{{#if (equalTo (getSubprotocol form operation) "longpoll")}}
+async function {{toCamelCase (joinStr operation affordance)}}() {
+    while (true) {
+        try {
+            const response = await fetch(URL, {
+                method: "{{getMethod form operation}}",
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to {{joinStr operation affordance}}: ${response.status} ${response.statusText}`);
+            }
+
+            const {{affordance}} = await response.json();
+            console.log("{{affordance}} value:", {{affordance}});
+
+            return {{affordance}};
+        } catch (error) {
+            console.error("Error:", error);
+        }
+
+        // Adding a 500 ms delay before the next request
+        await new Promise(resolve => setTimeout(resolve, 500));
+    }
+}
+
+{{toCamelCase (joinStr operation affordance)}}();
+{{/if}}
+{{else}}
+{{!--if no observation/subscription return the following code --}}
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+const bodyInput = {{generateTestInput affordanceObject}};
+
+{{/if}}
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+async function {{toCamelCase (joinStr operation affordance)}}(inputValue) {
+{{else}}
+async function {{toCamelCase (joinStr operation affordance)}}() {
+{{/if}}
+    try {
+        const response = await fetch(URL, {
+            method: "{{getMethod form operation}}",
+            {{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+            headers: {
+                "Content-Type": "{{getContentType form}}",
+            },
+            body: JSON.stringify(inputValue),
+            {{/if}}
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to {{joinStr operation affordance}}: ${response.status} ${response.statusText}`);
+        }
+
+        const {{affordance}} = await response.json();
+        console.log("{{affordance}} value:", {{affordance}});
+
+        return {{affordance}};
+    } catch (error) {
+        console.error("Error:", error);
+    }
+}
+
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+{{toCamelCase (joinStr operation affordance)}}(bodyInput);
+{{else}}
+{{toCamelCase (joinStr operation affordance)}}();
+{{/if}}
+{{/if}}

--- a/node/code-gen/src/templates/http/javascript/node-wot/template.hbs
+++ b/node/code-gen/src/templates/http/javascript/node-wot/template.hbs
@@ -1,0 +1,53 @@
+const { Servient } = require("@node-wot/core");
+const { HttpClientFactory } = require("@node-wot/binding-http");
+
+const servient = new Servient();
+servient.addClientFactory(new HttpClientFactory(null));
+
+servient.start().then(async (WoT) => {
+
+    //Utilize the link to your Thing Description or enter your Thing Description directly
+    //const td = await WoT.requestThingDescription(/*Path to Thing Description*/);
+    const td = {...};
+    let thing = await WoT.consume(td);
+    
+    {{#if (equalTo affordanceType "properties")}}
+    {{#if (equalTo operation "readproperty")}}
+    // Reading a property
+    let {{affordance}} = await (await thing.readProperty("{{affordance}}")).value();
+    console.log("{{affordance}} value:", {{affordance}});
+    {{/if}}
+    {{#if (equalTo operation "writeproperty")}}
+    // Writing to a property
+    await thing.writeProperty("{{affordance}}", {{generateTestInput affordanceObject}});
+    {{/if}}
+    {{#if (or (equalTo operation "observeproperty") (equalTo operation "unobserveproperty"))}}
+    // Observing a property
+    thing.observeProperty("{{affordance}}", async (data) => {
+        console.log("{{affordance}} value:", await data.value());
+    });
+    {{/if}}
+    {{/if}}
+    {{#if (equalTo affordanceType "actions")}}
+    {{#if (equalTo operation "invokeaction")}}
+    // Invoking an action
+    let {{affordance}} = await thing.invokeAction("{{affordance}}", {{generateTestInput affordanceObject}});
+    console.log("{{affordance}} value:", await {{affordance}}.value());
+    {{/if}}
+    {{/if}}
+    {{#if (equalTo affordanceType "events")}}
+    {{#if (or (equalTo operation "subscribeevent") (equalTo operation "unsubscribeevent"))}}
+    // Subscribing to an event
+    thing.subscribeEvent("{{affordance}}", async (data) => {
+        console.log("Event data:", await data.value());
+    });
+
+    // Unsubscribe after a certain period of time
+    setTimeout(() => {
+        thing.unsubscribeEvent("{{affordance}}");
+        console.log('Unsubscribed from {{affordance}} event');
+    }, 10000);
+    {{/if}}
+    {{/if}}
+
+}).catch((err) => { console.error(err); });

--- a/node/code-gen/src/templates/http/python/requests/template.hbs
+++ b/node/code-gen/src/templates/http/python/requests/template.hbs
@@ -1,0 +1,50 @@
+import requests
+
+URL = "{{absoluteURL}}"
+
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+payload = {{generateTestInput affordanceObject}}
+
+{{/if}}
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+def {{toSnakeCase (joinStr operation affordance)}}(payload_value):
+{{else}}
+def {{toSnakeCase (joinStr operation affordance)}}():
+{{/if}}
+{{#if (or (equalTo operation 'observeproperty') (equalTo operation 'subscribeevent'))}}
+  while True:
+    try: 
+      response = requests.get(URL, stream=True, timeout=10)
+
+      if response.status_code == 200:
+        for line in response.iter_lines():
+          if line:
+            data = line.decode("utf-8")
+            print(data)
+      else:
+        print(f"Failed to {{joinStr operation affordance}}. Status code: {response.status_code}, Response: {response.text}")
+        break
+
+    # Closing the connection after timeout or on error
+    except requests.exceptions.RequestException as error:
+      print("Error during the request:", error)
+      break
+{{else}}
+  try:
+    response = requests.{{toLowerCase (getMethod form operation)}}(URL{{#if (or (equalTo (getMethod form operation) "POST") (equalTo (getMethod form operation) "PUT"))}},json=payload_value, headers={"Content-Type": "{{getContentType form}}"}{{/if}})
+    if response.status_code == 200:
+      {{affordance}} = response.json()
+      print("{{affordance}} value:", {{affordance}})
+      return {{affordance}}
+    else:
+      print(f"Failed to {{joinStr operation affordance}}. Status code: {response.status_code}, Response: {response.text}")
+
+  except requests.exceptions.RequestException as error:
+    print("Error during the request:", error)
+{{/if}}
+
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+{{toSnakeCase (joinStr operation affordance)}}(payload)
+{{else}}
+{{toSnakeCase (joinStr operation affordance)}}()
+{{/if}}

--- a/node/code-gen/src/templates/modbus/javascript/modbus-serial/template.hbs
+++ b/node/code-gen/src/templates/modbus/javascript/modbus-serial/template.hbs
@@ -1,0 +1,73 @@
+const ModbusRTU = require("modbus-serial")
+
+const client = new ModbusRTU();
+
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+const payload = {{generateTestInput affordanceObject}};
+
+async function {{toCamelCase (joinStr operation affordance)}}(inputValue) {
+{{else}}
+async function {{toCamelCase (joinStr operation affordance)}}() {
+{{/if}}
+    try {
+        await client.connectTCP("{{getIP absoluteURL}}", { port: {{getPort absoluteURL}} });
+
+        client.setID({{getUnitID absoluteURL}});
+
+        const address = {{getAddress absoluteURL}};
+        
+        {{#if (equalTo operation 'readproperty')}}
+        const res = await client.{{getModbusFunction form operation}}(address, {{getQuantity absoluteURL}});
+        console.log("{{affordance}} value: ", res.data[0]);
+        return res.data[0];
+        {{!--client.close();--}}
+        {{/if}}
+        {{!--Output code for invoking an action or writing to a property --}}
+        {{#if (or (equalTo operation 'writeproperty') (equalTo operation 'invokeaction'))}}
+        {{#if (or (equalTo (getModbusFunction form operation) 'writeCoil') (equalTo (getModbusFunction form operation) 'writeRegister'))}}
+        const res = await client.{{getModbusFunction form operation}}(address, inputValue);
+        {{/if}}
+        {{#if (or (equalTo (getModbusFunction form operation) 'writeCoils') (equalTo (getModbusFunction form operation) 'writeRegisters'))}}
+        const res = await client.{{getModbusFunction form operation}}(address, [inputValue]);
+        {{/if}}
+        {{#if (or (equalTo (getModbusFunction form operation) 'writeCoil') (equalTo (getModbusFunction form operation) 'writeCoils'))}}
+        console.log("{{affordance}} value: ", res["state"]);
+        return res["state"];
+        {{/if}}
+        {{#if (or (equalTo (getModbusFunction form operation) 'writeRegister') (equalTo (getModbusFunction form operation) 'writeRegisters'))}}
+        console.log("{{affordance}} value: ", res["value"]);
+        return res["value"];
+        {{/if}}
+        {{!--client.close();--}}
+        {{/if}}
+        {{!--Output code for observation --}}
+        {{#if (or (equalTo operation 'observeproperty') (equalTo operation 'subscribeevent'))}}
+        // read values every {{getPollingTime form}} ms
+        const intervalId = setInterval(async () => {
+            try {
+                const res = await client.{{getModbusFunction form operation}}(address, {{getQuantity absoluteURL}});
+                console.log("{{affordance}} value: ", res.data[0]);
+            } catch (err) {
+                console.error("Failed to {{joinStr operation affordance}}", err);
+            }
+        }, {{getPollingTime form}});
+
+        // Stop observing after 10 seconds
+        setTimeout(() => {
+            clearInterval(intervalId);
+            console.log("Stopped observing {{affordance}}.");
+            client.close();
+        }, 10000);
+        {{/if}}
+
+    } catch (err) {
+        console.error("Failed to {{joinStr operation affordance}}", err);
+        client.close();
+    }
+}
+
+{{#if (or (equalTo operation "invokeaction") (equalTo operation "writeproperty"))}}
+{{toCamelCase (joinStr operation affordance)}}(payload);
+{{else}}
+{{toCamelCase (joinStr operation affordance)}}();
+{{/if}}

--- a/node/code-gen/src/templates/modbus/javascript/node-wot/template.hbs
+++ b/node/code-gen/src/templates/modbus/javascript/node-wot/template.hbs
@@ -1,0 +1,53 @@
+const { Servient } = require("@node-wot/core");
+const { ModbusClientFactory } = require("@node-wot/binding-modbus");
+
+const servient = new Servient();
+servient.addClientFactory(new ModbusClientFactory());
+
+servient.start().then(async (WoT) => {
+
+    //Utilize the link to your Thing Description or enter your Thing Description directly
+    //const td = await WoT.requestThingDescription(/*Path to Thing Description*/);
+    const td = {...};
+    let thing = await WoT.consume(td);
+    
+    {{#if (equalTo affordanceType "properties")}}
+    {{#if (equalTo operation "readproperty")}}
+    // Reading a property
+    let {{affordance}} = await (await thing.readProperty("{{affordance}}")).value();
+    console.log("{{affordance}} value:", {{affordance}});
+    {{/if}}
+    {{#if (equalTo operation "writeproperty")}}
+    // Writing to a property
+    await thing.writeProperty("{{affordance}}", {{generateTestInput affordanceObject}});
+    {{/if}}
+    {{#if (or (equalTo operation "observeproperty") (equalTo operation "unobserveproperty"))}}
+    // Observing a property
+    thing.observeProperty("{{affordance}}", async (data) => {
+        console.log("{{affordance}} value:", await data.value());
+    });
+    {{/if}}
+    {{/if}}
+    {{#if (equalTo affordanceType "actions")}}
+    {{#if (equalTo operation "invokeaction")}}
+    // Invoking an action
+    let {{affordance}} = await thing.invokeAction("{{affordance}}", {{generateTestInput affordanceObject}});
+    console.log("{{affordance}} value:", await {{affordance}}.value());
+    {{/if}}
+    {{/if}}
+    {{#if (equalTo affordanceType "events")}}
+    {{#if (or (equalTo operation "subscribeevent") (equalTo operation "unsubscribeevent"))}}
+    // Subscribing to an event
+    thing.subscribeEvent("{{affordance}}", async (data) => {
+        console.log("Event data:", await data.value());
+    });
+
+    // Unsubscribe after a certain period of time
+    setTimeout(() => {
+        thing.unsubscribeEvent("{{affordance}}");
+        console.log('Unsubscribed from {{affordance}} event');
+    }, 10000);
+    {{/if}}
+    {{/if}}
+
+}).catch((err) => { console.error(err); });

--- a/node/code-gen/src/templates/templates-paths.json
+++ b/node/code-gen/src/templates/templates-paths.json
@@ -1,0 +1,17 @@
+{
+    "http": {
+        "javascript": {
+            "fetch": "http/javascript/fetch/template.hbs",
+            "node-wot": "http/javascript/node-wot/template.hbs"
+        },
+        "python": {
+            "requests": "http/python/requests/template.hbs" 
+        }
+    },
+    "modbus": {
+        "javascript": {
+            "modbus-serial": "modbus/javascript/modbus-serial/template.hbs",
+            "node-wot": "modbus/javascript/node-wot/template.hbs"
+        }
+    }
+}

--- a/node/code-gen/src/util/util.js
+++ b/node/code-gen/src/util/util.js
@@ -1,0 +1,256 @@
+const { detectProtocolSchemes } = require('@thingweb/td-utils');
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Get the affordance type based on the affordance name (property, action, event)
+ * @param { Object } td 
+ * @param { String } affordance 
+ * @returns { String } affordanceType - the affordance type
+ */
+function getAffordanceType(td, affordance) {
+    let affordanceType;
+    for (const key in td) {
+        if (td.hasOwnProperty(key)) {
+            const value = td[key];
+
+            if (typeof value === 'object' && value !== null) {
+                if (affordance in value) {
+                    affordanceType = key;
+                }
+            }
+        }
+    }
+
+    if (affordanceType) {
+        return affordanceType;
+    }
+    else {
+        throw new Error(`The affordance ${affordance} was not found in the Thing Description`);
+    }
+}
+
+/**
+ * Parse the Thing Description and throw and error if it is invalid
+ * @param { String } td 
+ * @returns { Object } parsedTD
+ */
+function parseTD(td) {
+    try {
+        const parsedTD = JSON.parse(td);
+        return parsedTD;
+    } catch (error) {
+        throw new Error("Invalid JSON format! Please enter a valid TD.");
+    }
+}
+
+/**
+ * Get the available affordances in a Thing Description
+ * @param { Object } td 
+ * @returns { Array } affordanceOptions
+ */
+function getTDAffordances(td) {
+    const properties = td.properties ? Object.keys(td.properties) : [];
+    const actions = td.actions ? Object.keys(td.actions) : [];
+    const events = td.events ? Object.keys(td.events) : [];
+
+    const affordanceOptions = [...properties, ...actions, ...events];
+
+    if (affordanceOptions.length === 0) {
+        throw new Error('No affordances found in the Thing Description!');
+    } else {
+        return affordanceOptions;
+    }
+
+}
+
+/**
+ * Get the available forms indexes based on the affordance type and affordance name
+ * @param { Object } td 
+ * @param { String } affordanceType 
+ * @param { String } affordance 
+ * @returns { Array } availableIndexes
+ */
+function getFormIndexes(td, affordanceType, affordance) {
+    const availableForms = td[affordanceType][affordance].forms;
+
+    if (availableForms && availableForms.length > 0) {
+        const availableIndexes = Array.from(availableForms.keys());
+        return availableIndexes;
+    } else {
+        throw new Error('No forms available for the selected affordance!');
+    }
+}
+
+/**
+ * Get the available operations based on the affordance type, affordance name and form index
+ * @param { Object } td 
+ * @param { String } affordanceType 
+ * @param { String } affordance 
+ * @param { Integer } formIndex 
+ * @returns { Array } availableOperations
+ */
+function getOperations(td, affordanceType, affordance, formIndex) {
+
+    const operationList = {
+        properties: ['readproperty', 'writeproperty', 'observeproperty'],
+        actions: ['invokeaction'],
+        events: ['subscribeevent']
+    }
+
+    let availableOperations;
+
+    if (formIndex === null || formIndex === undefined || formIndex === '') {
+        availableOperations = [...operationList[affordanceType]]
+
+    } else {
+        const formOperations = td[affordanceType][affordance]['forms'][formIndex]['op'];
+
+        if (formOperations === undefined) {
+            availableOperations = [...operationList[affordanceType]]
+        }
+        else if (typeof formOperations === 'string') {
+            availableOperations = [formOperations];
+        } else if (typeof formOperations === 'object') {
+            availableOperations = [...formOperations];
+        } else {
+            throw new Error('Invalid type! Operations can only be a string or an array!');
+        }
+
+    }
+
+    //Remove the unobserveproperty and unsubscribeevent operations
+    availableOperations = availableOperations.filter(item => item !== "unobserveproperty" && item !== "unsubscribeevent");
+
+    return availableOperations;
+}
+
+/**
+ * Get the protocol schemes in a TD, check if they are available in the templates and only return the available ones
+ * @param { string } td 
+ * @param { string } file - the file with the available protocols
+ * @returns { Array } protocols
+ */
+function getTDProtocols(td) {
+
+    const pathsFile = require('../templates/templates-paths.json');
+    const availableProtocols = Object.keys(pathsFile);
+
+    const tdProtocols = Object.keys(detectProtocolSchemes(td));
+    let protocols = [];
+
+    //Check if the available protocols are in the TD
+    availableProtocols.forEach(availableProtocol => {
+        tdProtocols.forEach(tdProtocol => {
+            if (tdProtocol.includes(availableProtocol)) {
+                protocols.push(availableProtocol);
+            }
+        })
+    })
+
+    //Remove duplicates
+    protocols = [...new Set(protocols)];
+
+    if (protocols.length > 0) {
+        return protocols;
+    }
+}
+
+
+/**
+ * Get the available languages based on the protocols
+ * @param { Array } protocols 
+ * @returns { Array } availableLanguages
+ */
+function getAvailableLanguages(protocols) {
+    try {
+        const pathsFile = require('../templates/templates-paths.json');
+        let availableLanguages = [];
+
+        Object.entries(pathsFile).forEach(([key, value]) => {
+            protocols.forEach(protocol => {
+                if (key === protocol) {
+                    Object.entries(value).forEach(([language, libraries]) => {
+                        availableLanguages.push({ [language]: Object.keys(libraries) });
+                    });
+                }
+            });
+        });
+
+        availableLanguages = [...new Set(availableLanguages)];
+        
+        return availableLanguages;
+
+    } catch (error) {
+        throw new Error("No programming languages available for the specified protocols");
+    }
+}
+
+/**
+ * Get the available libraries based on the selected language and the available languages
+ * @param { String } selectedLanguage 
+ * @param { Array } languageList 
+ * @returns { Array } availableLibraries
+ */
+function getAvailableLibraries(selectedLanguage, languageList) {
+    let availableLibraries = [];
+
+    languageList.forEach(language => {
+        if (language[selectedLanguage]) {
+            availableLibraries.push(...language[selectedLanguage]);
+        }
+    })
+
+    availableLibraries = [...new Set(availableLibraries)];
+
+    return availableLibraries;
+}
+
+/**
+ * Generate a file with the output code
+ * @param { String } affordance 
+ * @param { String } operation 
+ * @param { String } programmingLanguage 
+ * @param { String } outputCode 
+ */
+async function generateFile(affordance, operation, programmingLanguage, outputCode) {
+    const folderName = 'generator-output';
+    let fileName;
+
+    if (programmingLanguage === 'python') {
+        fileName = `${affordance}_${operation}.py`;
+    }
+    else if (programmingLanguage === 'javascript') {
+        fileName = `${affordance}_${operation}.js`;
+    } else {
+        fileName = `${affordance}_${operation}_${programmingLanguage}.txt`;
+    }
+
+    if (!fs.existsSync(folderName)) {
+        fs.mkdirSync(folderName); // Create the folder if it doesn't exist
+    }
+
+    const filePath = path.join(folderName, fileName);
+
+    fs.writeFile(filePath, outputCode, (err) => {
+        if (err) {
+            throw new Error('An error occurred while writing the file!');
+        } else {
+            console.log(chalk.blue(`The file '${fileName}' was added to the '${folderName}' folder.`));
+        }
+    });
+}
+
+// Export the functions
+module.exports = {
+    getAffordanceType,
+    parseTD,
+    getTDAffordances,
+    getFormIndexes,
+    getOperations,
+    getTDProtocols,
+    getAvailableLanguages,
+    getAvailableLibraries,
+    generateFile
+}


### PR DESCRIPTION
This PR is meant to include the code generator as a new tool within the td-tools repository.

Although it can already be used, this package still lacks the appropriate bundling (browser and esm). I attempted to generate the respective bundles with `browserify` and `babel` as well as with `esbuild`, but they all failed, and I have not been able to make them work properly.

* Browserify and Babel failed even to create the bundle, so it cannot even be tested.
* Esbuild creates the respective bundles, but when trying to implement them in Playground, it fails.

This [link](https://gist.github.com/SergioCasCeb/839a88dc46abce8449b34adf108ba299) shows the `esbuild.js` file that I was utilizing for the esbuild bundling. @relu91 Since I am using basically the same esbuild file that was used for the node-wot browser bundle, do you by any chance know what might be happening, or any recommendation in general?

Also, for more context on what is going on, here are a few screenshots of the errors that I always end up encountering.
![Screenshot 2025-03-31 142538](https://github.com/user-attachments/assets/f1ee36ec-64ba-4bee-a071-6dc4bb1a08b4)
![Screenshot 2025-03-31 142654](https://github.com/user-attachments/assets/ac1142e6-7bf6-48d3-b289-ef371df28aad)


Notes: 
* Tests will be added later on.
* The way to get the Templates will also be changed to not rely on fetching from GitHub.
* The contribution section within the README file will also change once the Templates are fixed.

