### PR TITLE
chore: update CI node version to 20 & 22

### DIFF
--- a/.github/workflows/ci-aas-aid.yaml
+++ b/.github/workflows/ci-aas-aid.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 

--- a/.github/workflows/ci-async-api-converter.yaml
+++ b/.github/workflows/ci-async-api-converter.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 

--- a/.github/workflows/ci-json-spell-checker.yaml
+++ b/.github/workflows/ci-json-spell-checker.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 

--- a/.github/workflows/ci-open-api-converter.yaml
+++ b/.github/workflows/ci-open-api-converter.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 

--- a/.github/workflows/ci-td-utils.yaml
+++ b/.github/workflows/ci-td-utils.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 

--- a/.github/workflows/ci-thing-model.yaml
+++ b/.github/workflows/ci-thing-model.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     timeout-minutes: 30
 


### PR DESCRIPTION
Note: used to be 18 & 20

fixes https://github.com/eclipse-thingweb/td-tools/issues/63