### PR TITLE
Ship compiled dist/ so @thingweb/code-gen is consumable

### DIFF
--- a/node/code-gen/package.json
+++ b/node/code-gen/package.json
@@ -2,9 +2,24 @@
     "name": "@thingweb/code-gen",
     "author": "Eclipse Thingweb <thingweb-dev@eclipse.org> (https://thingweb.io/)",
     "license": "EPL-2.0 OR W3C-20150513",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Generates code snippets for Thing Descriptions. Supports multiple programming languages. For unsupported languages generates a prompt for an llm to generate the code snippet.",
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "bin": {
+        "code-gen": "dist/cli.js"
+    },
+    "files": [
+        "dist",
+        "README.md",
+        "LICENSE"
+    ],
     "homepage": "https://thingweb.io",
     "bugs": {
         "url": "https://github.com/eclipse-thingweb/td-tools/issues"
@@ -19,7 +34,8 @@
     },
     "type": "module",
     "scripts": {
-        "build": "tsc --outDir dist",
+        "build": "tsc -p tsconfig.build.json",
+        "prepack": "npm run build",
         "cli": "tsx src/cli.ts ",
         "test": "vitest run"
     },

--- a/node/code-gen/src/cli.ts
+++ b/node/code-gen/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { input, search, select, Separator } from "@inquirer/prompts";
 import {

--- a/node/code-gen/tsconfig.build.json
+++ b/node/code-gen/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["src/tests/**"]
+}


### PR DESCRIPTION
## Problem

`@thingweb/code-gen@1.0.0` (the only version on npm) is broken. Its `package.json`
declares `"main": "dist/index.js"`, but the published tarball shipped only the
`src/*.ts` TypeScript sources — no compiled `dist/`. Consumers (bundlers like
webpack, or `node`/`import`) fail to resolve the package:

Module not found: Error: Can't resolve '@thingweb/code-gen'
node_modules/@thingweb/code-gen doesn't exist (main -> dist/index.js missing)


Root cause: published without a build step and without a `files` allow-list /
`prepack` hook to guarantee `dist/` is compiled and included.

## Changes

- **`package.json`**
  - Added `"prepack": "npm run build"` so `dist/` is always built before pack/publish.
  - Added `"files": ["dist", "README.md", "LICENSE"]` allow-list (overrides the
    `.gitignore` `dist` exclusion for the tarball; keeps `src/`/tests out).
  - Added `"types": "dist/index.d.ts"` and a modern `exports` map (`types` + `import`).
  - Changed `build` to `tsc -p tsconfig.build.json`.
  - Added a `bin` entry (`code-gen` → `dist/cli.js`), kept out of the library `exports`.
  - Bumped version `1.0.0` → `1.0.1`.
- **`tsconfig.build.json`** (new): extends `tsconfig.json` and excludes `src/tests/**`
  so vitest test files are never compiled/shipped.
- **`src/cli.ts`**: added `#!/usr/bin/env node` shebang so the `bin` is executable.

## Release note

Publish `1.0.1` after merge to replace the broken `1.0.0` on npm.