### PR TITLE
fix(python/lorawan): generate the device catalog before running tests

### DIFF
--- a/.github/workflows/python-ci-lorawan.yml
+++ b/.github/workflows/python-ci-lorawan.yml
@@ -30,6 +30,10 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
+            - name: Generate device catalog
+              working-directory: python/lorawan
+              run: uv run python -m scripts.generate_device_tds
+
             - name: Run tests
               working-directory: python/lorawan
               run: uv run --dev pytest

--- a/python/lorawan/README.md
+++ b/python/lorawan/README.md
@@ -393,10 +393,15 @@ The single remaining skip is legitimate, not a regression:
 ## Development
 
 ```bash
+uv run python -m scripts.generate_device_tds   # generate examples/devices/ (see below)
 uv run pytest          # run the test suite
 uv run ruff check .    # lint
 uv run ruff format .   # format
 ```
+
+`examples/devices/` is generated, not checked in, so `tests/test_device_catalog.py`
+fails on a fresh clone until you run the generator once. CI does this before
+running the test suite.
 
 ## Scope & roadmap
 


### PR DESCRIPTION
The device-catalog Thing Descriptions under examples/devices/ are generated artifacts and gitignored, so test_device_catalog.py fails on a fresh clone and in CI, where nothing has ever run the generator.

Run scripts.generate_device_tds before pytest in the workflow, and document the generator alongside the other development commands so a new contributor hits it before the failing test rather than after.