### PR TITLE
fix(python/lorawan): declare validRange in the binding vocabulary

### DIFF
--- a/python/lorawan/README.md
+++ b/python/lorawan/README.md
@@ -92,8 +92,8 @@ uv run lorawan-wot decode examples/dragino-lht65n.td.json 0B450A8C02DD010A1E --f
 #    }
 ```
 
-For a `ports` layout, don't forget to pass the frame port:
-
+For a `ports` layout, don't forget to pass the frame port with `--fport`, as in
+the example above; without it the interpreter cannot select the right field set.
 
 ### Use it from Python
 
@@ -126,7 +126,7 @@ schema into a starter Thing Description.
 uv run lorawan-wot generate external/device-payload-schema/schemas/devices/makerfabs/ath20.yaml -o examples/devices/makerfabs/ath20.td.json
 ```
 
-This is how to generat a bundled [device catalog](#device-catalog).
+This is how the bundled [device catalog](#device-catalog) is generated.
 
 
 ## Generate a ChirpStack / TTN JavaScript codec
@@ -236,6 +236,7 @@ For `tlv`/`ctv` you may declare the tag fields at Thing level with
 | `lorav:length` | Byte length for `bytes`/`string`/`hex` (`-1` = consume rest) | `length` |
 | `lorav:unece` | UN/CEFACT unit code | `unece` |
 | `lorav:enum` | Map raw integers to labels | `values` |
+| `lorav:validRange` | Plausibility range `[min, max]`; decoded values outside it are flagged | `valid_range` |
 | `lorav:slot` | Order of a property within its group (multi-field TLV / flagged / match) | field order |
 | `lorav:presenceField` | Name of the bit-flags property that gates this property | `flagged.field` |
 | `lorav:presenceBit` | Bit index in `presenceField` that must be set for this property to appear | `flagged.groups[*].bit` |

--- a/python/lorawan/pyproject.toml
+++ b/python/lorawan/pyproject.toml
@@ -49,4 +49,4 @@ select = ["E", "F", "I", "B", "C4", "UP", "N", "W"]
 testpaths = ["tests"]
 
 [project.urls]
-Source = "https://github.com/eclipse-thingweb/td-tools/tree/main/node/python/lorawan"
+Source = "https://github.com/eclipse-thingweb/td-tools/tree/main/python/lorawan"

--- a/python/lorawan/vocab/context.jsonld
+++ b/python/lorawan/vocab/context.jsonld
@@ -30,6 +30,7 @@
     "guard": "lorav:guard",
     "unece": "lorav:unece",
     "enum": "lorav:enum",
+    "validRange": "lorav:validRange",
 
     "devEUI": "lorav:devEUI",
     "joinEUI": "lorav:joinEUI",

--- a/python/lorawan/vocab/ontology.ttl
+++ b/python/lorawan/vocab/ontology.ttl
@@ -87,6 +87,10 @@ lorav:enum a owl:DatatypeProperty ;
     rdfs:label "enumeration" ;
     rdfs:comment "Mapping from raw integer values to labels." .
 
+lorav:validRange a owl:DatatypeProperty ;
+    rdfs:label "valid range" ;
+    rdfs:comment "Plausibility range [min, max]; the interpreter flags decoded values outside it." .
+
 # --- Grouping / conditional-presence terms -----------------------------------
 
 lorav:slot a owl:DatatypeProperty ;


### PR DESCRIPTION
The converter emits lorav:validRange and the form JSON Schema accepts it, but the term is declared nowhere: not in ontology.ttl, not in context.jsonld, not in the README term table. A Thing Description carrying it therefore does not resolve under the published JSON-LD context, so the binding emits a term its own vocabulary does not define.

Declare it in all three places, described as a plausibility range whose out-of-range values the interpreter flags.

Correct two stale documents found alongside it: the package Source URL still points at the old node/python path the package was moved out of, and the note about ports layouts breaks off mid-sentence without saying to pass --fport.